### PR TITLE
Remove "css" from inputFormats

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var postcss = require('postcss')
 var loop = require('simple-loop')
 
 exports.name = 'postcss'
-exports.inputFormats = ['postcss', 'css']
 exports.outputFormat = 'css'
 
 function sanitizePlugins(pluginsToLoad) {


### PR DESCRIPTION
It ends up processing with PostCSS, and then processing again through PostCSS when it sees it outputted CSS. We should just have inputformats process once, and be specific about input.